### PR TITLE
A couple of posts and entries on publications

### DIFF
--- a/_posts/2025-08-14-ICDCS_2025.md
+++ b/_posts/2025-08-14-ICDCS_2025.md
@@ -8,7 +8,7 @@ categories: conferences
 Ryo Yanagida from the group attended the [45th IEEE International Conference on Distributed Computing Systems (ICDCS 2025)](https://icdcs2025.icdcs.org), which took place in Glasgow back in late July. (July 20th — July 23rd)
 
 Ryo presented the following two papers:
-1. R. Yanagida, J. Singer, P. Harvey, L. Wong, and C. Perkins. “Distributing Quality of Service (QoS) Policies in Name-based Networks”, ANMS Workshop in conjunction with the 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK.
-2. R. Yanagida, J. Singer, P. Harvey, L. Wong, and C. Perkins. “Name-based Quality of Service for Name-based Network”, The 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. 
+1. R. Yanagida, J. Singer, P. Harvey, L. Wong, and C. Perkins. “Distributing Quality of Service (QoS) Policies in Name-based Networks”, ANMS Workshop in conjunction with the 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. [doi: 10.1109/ICDCSW63273.2025.00123](https://doi.org/10.1109/ICDCSW63273.2025.00123)
+2. R. Yanagida, J. Singer, P. Harvey, L. Wong, and C. Perkins. “Name-based Quality of Service for Name-based Network”, The 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. [doi: 10.1109/ICDCSW63273.2025.00057](https://doi.org/10.1109/ICDCSW63273.2025.00057)
 
 [1] was presented during the [Fourth International Workshop on Autonomous Network Management Systems (ANMS 2025)](https://anms-conf.github.io), which was co-located with the ICDCS 2025. [2] was presented during the Industry I session during the main conference event. 

--- a/_posts/2025-10-29-SCONE-2025.md
+++ b/_posts/2025-10-29-SCONE-2025.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title:  "SCONE 2025 at Abertay"
+date: 2025-10-29 23:12:00 +0000
+categories: event
+---
+
+Elizabeth Boswell, Yuting Wan, Mihail Yanev, Ryo Yanagida, and Colin Perkins from the group attended [Scottish Networking Event (SCONE)](https://scone.cs.st-andrews.ac.uk/meetings/29-10-2025/), hosted at Abertay University in Dundee. 
+
+Along with a range of talks, Yuting presented his work on NDN producer mobility. 
+PhD students also had the opportunity to practice communicating their research to other academics. 
+
+The event concluded with a social hour in a nearby pub. 

--- a/_posts/2025-11-19-Cybersecurity_Meetup.md
+++ b/_posts/2025-11-19-Cybersecurity_Meetup.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  "Glasgow CS MSc Cybersecurity Meet-up"
+date: 2025-11-19 10:12:00 +0000
+categories: event
+---
+
+Ryo Yanagida and Vivian Band from the group attended the Glasgow CS MSc Cybersecurity Meet-up on 18/11/2025. This event was organised by Prof. Jeremy Singer for the MSc Cybersecurity cohort. 
+
+Vivian gave a talk about the cybersecurity industry and community, drawing from their experience in the field. This was followed by a talk from Kai Feng, Jeremy's PhD student, about his research in cybersecurity. 
+
+The event concluded with a short networking session, where the MSc cohort had the chance to talk to lecturers, professors, and PhD students in the field. 

--- a/publications.md
+++ b/publications.md
@@ -6,10 +6,10 @@ permalink: /publications/
 
 ## 2025 
 
-   * R. Yanagida, J. Singer, P. Harvey, L. Wong, and C. Perkins. “Distributing Quality of Service (QoS) Policies in Name-based Networks”, ANMS Workshop in conjunction with the 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. 
+   * Ryo Yanagida, Jeremy Singer, Paul Harvey, Leon Wong, and Colin Perkins. “Distributing Quality of Service (QoS) Policies in Name-based Networks”, ANMS Workshop in conjunction with the 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. 
     [doi: 10.1109/ICDCSW63273.2025.00123](https://doi.org/10.1109/ICDCSW63273.2025.00123)
    
-   * R. Yanagida, J. Singer, P. Harvey, L. Wong, and C. Perkins. “Name-based Quality of Service for Name-based Network”, The 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. 
+   * Ryo Yanagida, Jeremy Singer, Paul Harvey, Leon Wong, and Colin Perkins. “Name-based Quality of Service for Name-based Network”, The 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. 
     [doi: 10.1109/ICDCSW63273.2025.00057](https://doi.org/10.1109/ICDCSW63273.2025.00057)
 
 ## 2024

--- a/publications.md
+++ b/publications.md
@@ -4,6 +4,14 @@ title: Publications
 permalink: /publications/
 ---
 
+## 2025 
+
+   * R. Yanagida, J. Singer, P. Harvey, L. Wong, and C. Perkins. “Distributing Quality of Service (QoS) Policies in Name-based Networks”, ANMS Workshop in conjunction with the 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. 
+    [doi: 10.1109/ICDCSW63273.2025.00123](https://doi.org/10.1109/ICDCSW63273.2025.00123)
+   
+   * R. Yanagida, J. Singer, P. Harvey, L. Wong, and C. Perkins. “Name-based Quality of Service for Name-based Network”, The 45th IEEE International Conference on Distributed Computing Systems (ICDCS), Glasgow, Scotland, UK. 
+    [doi: 10.1109/ICDCSW63273.2025.00057](https://doi.org/10.1109/ICDCSW63273.2025.00057)
+
 ## 2024
 
  * Matthew Russell Barnes, Mladen Karan, Stephen McQuistin, Colin Perkins,


### PR DESCRIPTION
(apologies for bundling all the changes in a single pull-request)
This adds the following two posts:
- SCONE 
- Cybersecurity Meetup (Vivian gave a talk)

This also adds publication entry in the `publications.md`, as well as adding DOI in the previous ICDCS conference post.